### PR TITLE
feat: timestamps download links

### DIFF
--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -1595,3 +1595,9 @@ export const onFetchRecordTimestamps = (
   version
 ) =>
   withCsrf((__, _, csrf) => api.recordsTimestamp(csrf, token, state, version));
+
+// Comments Actions
+export const onFetchCommentsTimestamps = (token, state, commentsids) =>
+  withCsrf((__, _, csrf) =>
+    api.commentsTimestamp(csrf, token, state, commentsids)
+  );

--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -1599,5 +1599,9 @@ export const onFetchRecordTimestamps = (
 // Comments Actions
 export const onFetchCommentsTimestamps = (token, state, commentsids) =>
   withCsrf((__, _, csrf) =>
-    api.commentsTimestamp(csrf, token, state, commentsids)
+    api.commentsTimestamps(csrf, token, state, commentsids)
   );
+
+// Ticket Vote actions
+export const onFetchTicketVoteTimestamps = (token) =>
+  withCsrf((__, _, csrf) => api.ticketVoteTimestamps(csrf, token));

--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -1587,3 +1587,11 @@ export const onSubmitDccComment = (currentUserID, token, comment, parentid) =>
         throw error;
       });
   });
+
+// Records Actions
+export const onFetchRecordTimestamps = (
+  token,
+  state = PROPOSAL_STATE_VETTED,
+  version
+) =>
+  withCsrf((__, _, csrf) => api.recordsTimestamp(csrf, token, state, version));

--- a/src/components/DownloadJSON.jsx
+++ b/src/components/DownloadJSON.jsx
@@ -3,16 +3,35 @@ import PropTypes from "prop-types";
 import fileDownload from "js-file-download";
 import { Link } from "pi-ui";
 
+const validateBeforeDownloadProp = function (props, propName) {
+  if (
+    props["isAsync"] === true &&
+    props[propName] === undefined &&
+    !(props[propName] instanceof Promise)
+  ) {
+    throw new Error("beforeDownload prop must be a Promise");
+  }
+};
+
 const DownloadJSON = ({
   content,
   fileName,
   label,
   customComponent,
+  isAsync,
+  beforeDownload,
   ...props
 }) => {
   function onDownload() {
     const data = JSON.stringify(content, null, 2);
     fileDownload(data, `${fileName}.json`);
+  }
+
+  function handleDownload() {
+    beforeDownload().then((response) => {
+      const data = JSON.stringify(response, null, 2);
+      fileDownload(data, `${fileName}.json`);
+    });
   }
 
   return customComponent ? (
@@ -21,7 +40,10 @@ const DownloadJSON = ({
     <Link
       {...props}
       customComponent={(props) => (
-        <span style={{ cursor: "pointer" }} {...props} onClick={onDownload}>
+        <span
+          style={{ cursor: "pointer" }}
+          {...props}
+          onClick={!isAsync ? onDownload : handleDownload}>
           {label}
         </span>
       )}
@@ -30,7 +52,8 @@ const DownloadJSON = ({
 };
 
 DownloadJSON.propTypes = {
-  content: PropTypes.oneOfType([PropTypes.object, PropTypes.array]).isRequired
+  content: PropTypes.oneOfType([PropTypes.object, PropTypes.array]).isRequired,
+  beforeDownload: validateBeforeDownloadProp
 };
 
 export default DownloadJSON;

--- a/src/components/DownloadJSON.jsx
+++ b/src/components/DownloadJSON.jsx
@@ -3,11 +3,11 @@ import PropTypes from "prop-types";
 import fileDownload from "js-file-download";
 import { Link } from "pi-ui";
 
-const validateBeforeDownloadProp = function (props, propName) {
+const validateBeforeDownloadProp = function (props, beforeDownload) {
   if (
     props["isAsync"] === true &&
-    props[propName] === undefined &&
-    !(props[propName] instanceof Promise)
+    props[beforeDownload] === undefined &&
+    !(props[beforeDownload] instanceof Promise)
   ) {
     throw new Error("beforeDownload prop must be a Promise");
   }

--- a/src/components/ModalDiff/ModalDiff.module.css
+++ b/src/components/ModalDiff/ModalDiff.module.css
@@ -9,7 +9,8 @@
 }
 
 .diffTabContent {
-  overflow-y: scroll;
+  min-height: 20rem;
+  overflow-y: auto;
   max-height: calc(70vh - 20rem);
 }
 

--- a/src/components/ModalDiff/ModalDiffProposal.jsx
+++ b/src/components/ModalDiff/ModalDiffProposal.jsx
@@ -77,7 +77,7 @@ const ModalDiffProposal = ({
         </Tab>
       </Tabs>
       <DownloadTimestamps
-        label="Download the Inclusion Proof for this version"
+        label="Download the Timestamp for this version"
         version={proposalDetails.version}
         token={proposalDetails.censorshiprecord.token}
       />

--- a/src/components/ModalDiff/ModalDiffProposal.jsx
+++ b/src/components/ModalDiff/ModalDiffProposal.jsx
@@ -7,7 +7,8 @@ import {
   Title,
   Author,
   Event,
-  Subtitle
+  Subtitle,
+  DownloadTimestamps
 } from "src/components/RecordWrapper";
 import styles from "./ModalDiff.module.css";
 
@@ -75,6 +76,11 @@ const ModalDiffProposal = ({
           <FilesDiff oldFiles={oldFiles} newFiles={newFiles} />
         </Tab>
       </Tabs>
+      <DownloadTimestamps
+        label="Download the Inclusion Proof for this version"
+        version={proposalDetails.version}
+        token={proposalDetails.censorshiprecord.token}
+      />
     </Modal>
   );
 };

--- a/src/components/ModalSearchVotes/ModalSearchVotes.jsx
+++ b/src/components/ModalSearchVotes/ModalSearchVotes.jsx
@@ -4,10 +4,17 @@ import { Formik } from "formik";
 import { useSearchVotes } from "./hooks";
 import styles from "./ModalSearchVotes.module.css";
 import validationSchema from "./validation";
+import DownloadJSON from "src/components/DownloadJSON";
+import useTimestamps from "src/hooks/api/useTimestamps";
 
 function findTicket(ticketToken, votes) {
-  return votes[ticketToken];
+  return votes.find((v) => v && v.ticket === ticketToken);
 }
+const getTimestampsFileName = (proposalToken, ticketToken) =>
+  `timestamps-${proposalToken.substring(0, 7)}-ticket-${ticketToken.substring(
+    0,
+    7
+  )}`;
 
 const ModalSearchVotes = ({ show, onClose, proposal }) => {
   const [ticketFound, setTicketFound] = useState(null);
@@ -15,6 +22,7 @@ const ModalSearchVotes = ({ show, onClose, proposal }) => {
     proposal.censorshiprecord.token,
     show
   );
+  const { onFetchTicketVoteTimestamps } = useTimestamps();
   function updateFoundTicket(ticket) {
     setTicketFound({
       Ticket: ticket.ticket,
@@ -38,6 +46,7 @@ const ModalSearchVotes = ({ show, onClose, proposal }) => {
     },
     [show]
   );
+
   const resultsTableHeaders = ["Ticket", "Option"];
   return (
     <Modal
@@ -88,11 +97,25 @@ const ModalSearchVotes = ({ show, onClose, proposal }) => {
         }}
       </Formik>
       {ticketFound && (
-        <Table
-          data={[ticketFound]}
-          headers={resultsTableHeaders}
-          disablePagination
-        />
+        <>
+          <Table
+            data={[ticketFound]}
+            headers={resultsTableHeaders}
+            disablePagination
+          />
+          <DownloadJSON
+            label="Download Ticket Vote Timestamps"
+            fileName={getTimestampsFileName(
+              proposal.censorshiprecord.token,
+              ticketFound.Ticket
+            )}
+            isAsync={true}
+            content={[]}
+            beforeDownload={() =>
+              onFetchTicketVoteTimestamps(proposal.censorshiprecord.token)
+            }
+          />
+        </>
       )}
     </Modal>
   );

--- a/src/components/Proposal/Proposal.jsx
+++ b/src/components/Proposal/Proposal.jsx
@@ -406,7 +406,7 @@ const Proposal = React.memo(function Proposal({
                     />
                   )}
                   <DownloadComments
-                    label="Comments Timestamp"
+                    label="Comments Timestamps"
                     recordToken={proposalToken}
                     isTimestamp={true}
                     state={state}

--- a/src/components/Proposal/Proposal.jsx
+++ b/src/components/Proposal/Proposal.jsx
@@ -392,7 +392,7 @@ const Proposal = React.memo(function Proposal({
                     label="Download Proposal Bundle"
                   />
                   <DownloadTimestamps
-                    label="Download Proposal Inclusion Proof"
+                    label="Download Proposal Timestamp"
                     token={proposalToken}
                     version={version}
                     state={state}

--- a/src/components/Proposal/Proposal.jsx
+++ b/src/components/Proposal/Proposal.jsx
@@ -200,6 +200,7 @@ const Proposal = React.memo(function Proposal({
           ChartsLink,
           CopyLink,
           DownloadRecord,
+          DownloadTimestamps,
           Header,
           Subtitle,
           Edit,
@@ -389,6 +390,12 @@ const Proposal = React.memo(function Proposal({
                     content={proposal}
                     className="margin-right-l"
                     label="Download Proposal Bundle"
+                  />
+                  <DownloadTimestamps
+                    label="Download Proposal Inclusion Proof"
+                    token={proposalToken}
+                    version={version}
+                    state={state}
                   />
                   {isPublic && !!comments && (
                     <DownloadComments

--- a/src/components/Proposal/Proposal.jsx
+++ b/src/components/Proposal/Proposal.jsx
@@ -201,6 +201,7 @@ const Proposal = React.memo(function Proposal({
           CopyLink,
           DownloadRecord,
           DownloadTimestamps,
+          LinkSection,
           Header,
           Subtitle,
           Edit,
@@ -384,26 +385,33 @@ const Proposal = React.memo(function Proposal({
             )}
             {extended && (
               <Row className={styles.lastRow} justify="space-between">
-                <Row className={styles.downloadLinksWrapper} noMargin>
+                <LinkSection
+                  className={styles.downloadLinksWrapper}
+                  title="Available Downloads">
                   <DownloadRecord
                     fileName={proposalToken}
                     content={proposal}
-                    className="margin-right-l"
-                    label="Download Proposal Bundle"
+                    label="Proposal Bundle"
                   />
                   <DownloadTimestamps
-                    label="Download Proposal Timestamp"
+                    label="Proposal Timestamps"
                     token={proposalToken}
                     version={version}
                     state={state}
                   />
-                  {isPublic && !!comments && (
+                  {isPublic && (
                     <DownloadComments
+                      label="Comments Bundle"
                       recordToken={proposalToken}
-                      className={styles.downloadCommentsLink}
                     />
                   )}
-                </Row>
+                  <DownloadComments
+                    label="Comments Timestamp"
+                    recordToken={proposalToken}
+                    isTimestamp={true}
+                    state={state}
+                  />
+                </LinkSection>
                 <Row className={styles.proposalActions}>
                   <CopyLink
                     className={classNames(

--- a/src/components/Proposal/Proposal.module.css
+++ b/src/components/Proposal/Proposal.module.css
@@ -135,15 +135,6 @@ span.statusTag > span {
     flex-direction: column;
   }
 
-  .downloadLinksWrapper {
-    flex-direction: column;
-  }
-
-  .downloadCommentsLink {
-    margin-right: 0;
-    margin-top: 1rem;
-  }
-
   .proposalActions {
     margin-top: 2rem;
   }

--- a/src/components/ProposalForm/DraftSaver.jsx
+++ b/src/components/ProposalForm/DraftSaver.jsx
@@ -91,8 +91,9 @@ const DraftSaver = ({
           { description, files },
           mapBlobToFile
         );
-        const filteredFiles = files.filter((file) =>
-          !markdownFiles.includes(file));
+        const filteredFiles = files.filter(
+          (file) => !markdownFiles.includes(file)
+        );
         setValues({
           name,
           description: text,

--- a/src/components/RecordWrapper/RecordWrapper.jsx
+++ b/src/components/RecordWrapper/RecordWrapper.jsx
@@ -25,6 +25,7 @@ import { useLoader } from "src/containers/Loader";
 import Join from "../Join";
 import CopyLink from "../CopyLink";
 import rfpTag from "src/assets/images/rfp-tag.svg";
+import useRecordTimestamps from "src/hooks/api/useRecordTimestamps";
 
 export const Author = ({ username, url }) => <Link to={url}>{username}</Link>;
 
@@ -266,6 +267,19 @@ export const RfpProposalLink = ({ url, rfpTitle }) => {
 
 export const DownloadRecord = DownloadJSON;
 
+export const DownloadTimestamps = ({ token, version, state, label }) => {
+  const { onFetchRecordTimestamps } = useRecordTimestamps();
+  return (
+    <DownloadJSON
+      label={label}
+      fileName={`timestamps-${token ? token.substring(0, 7) : ""}`}
+      isAsync={true}
+      content={[]}
+      beforeDownload={() => onFetchRecordTimestamps(token, state, version)}
+    />
+  );
+};
+
 const RecordWrapper = ({ children, className }) => (
   <Card className={classNames("container margin-bottom-m", className)}>
     {children({
@@ -280,6 +294,7 @@ const RecordWrapper = ({ children, className }) => (
       ChartsLink,
       CopyLink,
       DownloadRecord,
+      DownloadTimestamps,
       Header,
       Subtitle,
       Edit,

--- a/src/components/RecordWrapper/RecordWrapper.jsx
+++ b/src/components/RecordWrapper/RecordWrapper.jsx
@@ -16,7 +16,9 @@ import {
   Tooltip,
   CopyableText,
   useMediaQuery,
-  DEFAULT_DARK_THEME_NAME
+  DEFAULT_DARK_THEME_NAME,
+  Dropdown,
+  DropdownItem
 } from "pi-ui";
 import { Row } from "../layout";
 import Link from "../Link";
@@ -25,7 +27,7 @@ import { useLoader } from "src/containers/Loader";
 import Join from "../Join";
 import CopyLink from "../CopyLink";
 import rfpTag from "src/assets/images/rfp-tag.svg";
-import useRecordTimestamps from "src/hooks/api/useRecordTimestamps";
+import useTimestamps from "src/hooks/api/useTimestamps";
 
 export const Author = ({ username, url }) => <Link to={url}>{username}</Link>;
 
@@ -268,7 +270,7 @@ export const RfpProposalLink = ({ url, rfpTitle }) => {
 export const DownloadRecord = DownloadJSON;
 
 export const DownloadTimestamps = ({ token, version, state, label }) => {
-  const { onFetchRecordTimestamps } = useRecordTimestamps();
+  const { onFetchRecordTimestamps } = useTimestamps();
   return (
     <DownloadJSON
       label={label}
@@ -279,6 +281,14 @@ export const DownloadTimestamps = ({ token, version, state, label }) => {
     />
   );
 };
+
+export const LinkSection = ({ children, className, title }) => (
+  <Dropdown className={className} title={title}>
+    {React.Children.toArray(children).map((link, i) => (
+      <DropdownItem key={i}>{link}</DropdownItem>
+    ))}
+  </Dropdown>
+);
 
 const RecordWrapper = ({ children, className }) => (
   <Card className={classNames("container margin-bottom-m", className)}>
@@ -295,6 +305,7 @@ const RecordWrapper = ({ children, className }) => (
       CopyLink,
       DownloadRecord,
       DownloadTimestamps,
+      LinkSection,
       Header,
       Subtitle,
       Edit,

--- a/src/components/RecordWrapper/RecordWrapper.jsx
+++ b/src/components/RecordWrapper/RecordWrapper.jsx
@@ -272,7 +272,7 @@ export const DownloadTimestamps = ({ token, version, state, label }) => {
   return (
     <DownloadJSON
       label={label}
-      fileName={`timestamps-${token ? token.substring(0, 7) : ""}`}
+      fileName={`timestamps-${token ? token.substring(0, 7) : ""}-v${version}`}
       isAsync={true}
       content={[]}
       beforeDownload={() => onFetchRecordTimestamps(token, state, version)}

--- a/src/containers/Comments/Comment/CommentWrapper.jsx
+++ b/src/containers/Comments/Comment/CommentWrapper.jsx
@@ -67,6 +67,7 @@ const CommentWrapper = ({
   numOfReplies,
   isFlatMode,
   proposalState,
+  recordBaseLink,
   ...props
 }) => {
   const {
@@ -171,11 +172,10 @@ const CommentWrapper = ({
     />
   );
 
-  const shortToken = recordToken.substring(0, 7);
   return (
     <>
       <Comment
-        permalink={`/${recordType}s/${shortToken}/comments/${commentid}`}
+        permalink={`${recordBaseLink}/comments/${commentid}`}
         seeInContextLink={contextLink}
         censorable={censorable}
         author={username}

--- a/src/containers/Comments/Comments.jsx
+++ b/src/containers/Comments/Comments.jsx
@@ -45,7 +45,8 @@ const Comments = ({
   readOnlyReason,
   className,
   history,
-  proposalState
+  proposalState,
+  recordBaseLink
 }) => {
   const [, identityError] = useIdentity();
   const { isPaid, paywallEnabled } = usePaywall();
@@ -213,7 +214,7 @@ const Comments = ({
 
   const singleThreadCommentCannotBeAccessed =
     isSingleThread &&
-    ((comments && !comments.find((c) => c.commentid === threadParentID)) ||
+    ((comments && !comments.find((c) => c.commentid === +threadParentID)) ||
       numOfComments === 0);
 
   return (
@@ -318,6 +319,7 @@ const Comments = ({
                 recordToken,
                 threadParentID,
                 recordType,
+                proposalState,
                 readOnly,
                 identityError,
                 paywallMissing,
@@ -333,6 +335,7 @@ const Comments = ({
                 comments={state.comments}
                 isFlatMode={isFlatCommentsMode}
                 proposalState={proposalState}
+                recordsBaseLink={recordBaseLink}
               />
             </CommentContext.Provider>
           ) : null}

--- a/src/containers/Comments/CommentsList/CommentsList.jsx
+++ b/src/containers/Comments/CommentsList/CommentsList.jsx
@@ -1,15 +1,25 @@
 import React from "react";
 import CommentWrapper from "../Comment/CommentWrapper";
 
-const CommentsList = ({ comments, isFlatMode, proposalState }) =>
+const CommentsList = ({
+  comments,
+  isFlatMode,
+  proposalState,
+  recordBaseLink
+}) =>
   comments.map((comment) => (
     <CommentWrapper
       key={`comment-${comment.commentid}`}
       comment={comment}
       numOfReplies={(comment.children && comment.children.length) || 0}
       isFlatMode={isFlatMode}
+      recordBaseLink={recordBaseLink}
       proposalState={proposalState}>
-      <CommentsList comments={comment.children} proposalState={proposalState} />
+      <CommentsList
+        comments={comment.children}
+        proposalState={proposalState}
+        recordBaseLink={recordBaseLink}
+      />
     </CommentWrapper>
   ));
 

--- a/src/containers/Comments/CommentsList/CommentsListWrapper.jsx
+++ b/src/containers/Comments/CommentsList/CommentsListWrapper.jsx
@@ -53,7 +53,8 @@ const CommentsListWrapper = ({
   lastTimeAccessed,
   currentUserID,
   isFlatMode,
-  proposalState
+  proposalState,
+  recordsBaseLink
 }) => {
   const [nestedComments, setNestedComments] = useState([]);
   useEffect(
@@ -93,6 +94,7 @@ const CommentsListWrapper = ({
       comments={nestedComments}
       isFlatMode={isFlatMode}
       proposalState={proposalState}
+      recordBaseLink={recordsBaseLink}
     />
   );
 };

--- a/src/containers/Comments/Download/DownloadComments.jsx
+++ b/src/containers/Comments/Download/DownloadComments.jsx
@@ -3,24 +3,47 @@ import PropTypes from "prop-types";
 import DownloadJSON from "src/components/DownloadJSON";
 import { useDownloadComments } from "./hooks";
 
-const DownloadComments = ({ recordToken, className }) => {
-  const { comments } = useDownloadComments(recordToken);
-  return (
-    !!comments &&
-    !!comments.length && (
+const DownloadComments = ({
+  recordToken,
+  className,
+  isTimestamp,
+  state,
+  label
+}) => {
+  const { comments, onFetchCommentsTimestamps } = useDownloadComments(
+    recordToken
+  );
+  return !!comments && !!comments.length ? (
+    !isTimestamp ? (
       <DownloadJSON
-        label="Download Comments Bundle"
+        label={label}
         fileName={`${recordToken}-comments`}
         content={comments}
         className={className}
       />
+    ) : (
+      <DownloadJSON
+        label={label}
+        isAsync={true}
+        fileName={`timestamp-${
+          recordToken ? recordToken.substring(0, 7) : ""
+        }-comments`}
+        beforeDownload={() => onFetchCommentsTimestamps(recordToken, state)}
+        content={[]}
+      />
     )
-  );
+  ) : null;
 };
 
 DownloadComments.propTypes = {
   recordToken: PropTypes.string,
-  className: PropTypes.string
+  className: PropTypes.string,
+  isTimestamp: PropTypes.bool
+};
+DownloadComments.defaultProps = {
+  isTimestamp: false,
+  state: 0,
+  label: "Download Comments Bundle"
 };
 
 export default DownloadComments;

--- a/src/containers/Comments/Download/hooks.js
+++ b/src/containers/Comments/Download/hooks.js
@@ -1,6 +1,7 @@
 import { createContext, useContext, useMemo } from "react";
 import * as sel from "src/selectors";
 import { useSelector } from "src/redux";
+import useTimestamps from "src/hooks/api/useTimestamps";
 
 export const CommentContext = createContext();
 export const useComment = () => useContext(CommentContext);
@@ -10,5 +11,7 @@ export function useDownloadComments(token) {
     token
   ]);
   const comments = useSelector(commentsSelector);
-  return { comments };
+  const { onFetchCommentsTimestamps } = useTimestamps();
+
+  return { comments, onFetchCommentsTimestamps };
 }

--- a/src/containers/DCC/Detail/Detail.jsx
+++ b/src/containers/DCC/Detail/Detail.jsx
@@ -14,7 +14,7 @@ const DccDetail = ({ Main, match }) => {
   const dccToken = get("params.token", match);
   const threadParentCommentID = get("params.commentid", match);
   const { dcc, loading, error } = useDcc(dccToken);
-
+  const dccLink = `/dccs/${dccToken}`;
   return (
     <>
       <Main fillScreen>
@@ -35,6 +35,7 @@ const DccDetail = ({ Main, match }) => {
             readOnlyReason={
               "This DCC can no longer receive comments due its current status."
             }
+            recordBaseLink={dccLink}
           />
         </AdminDccActionsProvider>
       </Main>

--- a/src/containers/Invoice/Detail/Detail.jsx
+++ b/src/containers/Invoice/Detail/Detail.jsx
@@ -54,6 +54,7 @@ const InvoiceDetail = ({ Main, match }) => {
               readOnlyReason={
                 "This invoice can no longer receive comments due its current status."
               }
+              recordBaseLink={`/invoices/${invoiceToken}`}
             />
           )}
         </AdminInvoiceActionsProvider>

--- a/src/containers/Proposal/Detail/Detail.jsx
+++ b/src/containers/Proposal/Detail/Detail.jsx
@@ -12,7 +12,8 @@ import {
   isVotingFinishedProposal,
   getProposalToken,
   isCensoredProposal,
-  isAbandonedProposal
+  isAbandonedProposal,
+  getProposalLink
 } from "../helpers";
 import {
   UnvettedActionsProvider,
@@ -42,7 +43,6 @@ const ProposalDetail = ({ Main, match, state }) => {
   const { voteSummary } = useProposalVote(proposalToken);
   const canReceiveComments =
     !isVotingFinishedProposal(voteSummary) && !isAbandonedProposal(proposal);
-
   return (
     <>
       <Main className={styles.customMain} fillScreen>
@@ -69,6 +69,7 @@ const ProposalDetail = ({ Main, match, state }) => {
                 readOnly={!canReceiveComments}
                 readOnlyReason={getCommentBlockedReason(proposal, voteSummary)}
                 proposalState={state}
+                recordBaseLink={getProposalLink(proposal)}
               />
             )}
           </PublicActionsProvider>

--- a/src/containers/Proposal/helpers.js
+++ b/src/containers/Proposal/helpers.js
@@ -11,6 +11,7 @@ import {
   PROPOSAL_STATUS_UNREVIEWED_CHANGES,
   PROPOSAL_STATUS_CENSORED,
   PROPOSAL_STATE_VETTED,
+  PROPOSAL_STATE_UNVETTED,
   NOJS_ROUTE_PREFIX
 } from "../../constants";
 import { getTextFromIndexMd } from "src/helpers";
@@ -18,6 +19,7 @@ import set from "lodash/fp/set";
 import values from "lodash/fp/values";
 import pick from "lodash/pick";
 import isEmpty from "lodash/fp/isEmpty";
+import get from "lodash/fp/get";
 
 /**
  * Returns the total amount of votes received by a given proposal voteSummary
@@ -333,3 +335,16 @@ export const getProposalRfpLinks = (proposal, rfpSubmissions, proposals) => {
     ? { ...proposal, proposedFor: proposals[proposal.linkto].name }
     : proposal;
 };
+
+export const getProposalStateLabel = (proposalState) =>
+  get(proposalState)({
+    [PROPOSAL_STATE_VETTED]: "vetted",
+    [PROPOSAL_STATE_UNVETTED]: "unvetted"
+  });
+
+export const getProposalLink = (proposal) =>
+  proposal
+    ? `/proposals/${getProposalStateLabel(
+        proposal.state
+      )}/${proposal.censorshiprecord.token.substring(0, 7)}`
+    : "";

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -8,8 +8,8 @@ import * as pki from "./lib/pki";
 import { sha3_256 } from "js-sha3";
 import { capitalize } from "src/utils/strings";
 
-import { INVALID_FILE } from "./constants";
 import {
+  INVALID_FILE,
   INVOICE_STATUS_APPROVED,
   INVOICE_STATUS_DISPUTED,
   INVOICE_STATUS_NEW,

--- a/src/hooks/api/useRecordTimestamps.js
+++ b/src/hooks/api/useRecordTimestamps.js
@@ -1,7 +1,0 @@
-import * as act from "src/actions";
-import { useAction } from "src/redux";
-
-export default function useRecordTimestamps() {
-  const onFetchRecordTimestamps = useAction(act.onFetchRecordTimestamps);
-  return { onFetchRecordTimestamps };
-}

--- a/src/hooks/api/useRecordTimestamps.js
+++ b/src/hooks/api/useRecordTimestamps.js
@@ -1,0 +1,7 @@
+import * as act from "src/actions";
+import { useAction } from "src/redux";
+
+export default function useRecordTimestamps() {
+  const onFetchRecordTimestamps = useAction(act.onFetchRecordTimestamps);
+  return { onFetchRecordTimestamps };
+}

--- a/src/hooks/api/useTimestamps.js
+++ b/src/hooks/api/useTimestamps.js
@@ -1,0 +1,8 @@
+import * as act from "src/actions";
+import { useAction } from "src/redux";
+
+export default function useTimestamps() {
+  const onFetchRecordTimestamps = useAction(act.onFetchRecordTimestamps);
+  const onFetchCommentsTimestamps = useAction(act.onFetchCommentsTimestamps);
+  return { onFetchRecordTimestamps, onFetchCommentsTimestamps };
+}

--- a/src/hooks/api/useTimestamps.js
+++ b/src/hooks/api/useTimestamps.js
@@ -4,5 +4,12 @@ import { useAction } from "src/redux";
 export default function useTimestamps() {
   const onFetchRecordTimestamps = useAction(act.onFetchRecordTimestamps);
   const onFetchCommentsTimestamps = useAction(act.onFetchCommentsTimestamps);
-  return { onFetchRecordTimestamps, onFetchCommentsTimestamps };
+  const onFetchTicketVoteTimestamps = useAction(
+    act.onFetchTicketVoteTimestamps
+  );
+  return {
+    onFetchRecordTimestamps,
+    onFetchCommentsTimestamps,
+    onFetchTicketVoteTimestamps
+  };
 }

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -6,7 +6,7 @@ export { default as useNavigation } from "./api/useNavigation";
 export { default as usePaywall } from "./api/usePaywall";
 export { default as usePolicy } from "./api/usePolicy";
 export { default as useProposalsBatch } from "./api/useProposalsBatch";
-export { default as useRecordTimestamps } from "./api/useRecordTimestamps";
+export { default as useTimestamps } from "./api/useTimestamps";
 export { default as useSubContractors } from "./api/useSubContractors";
 export { default as useSupervisors } from "./api/useSupervisors";
 export { default as useUserDetail } from "./api/useUserDetail";

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -6,6 +6,7 @@ export { default as useNavigation } from "./api/useNavigation";
 export { default as usePaywall } from "./api/usePaywall";
 export { default as usePolicy } from "./api/usePolicy";
 export { default as useProposalsBatch } from "./api/useProposalsBatch";
+export { default as useRecordTimestamps } from "./api/useRecordTimestamps";
 export { default as useSubContractors } from "./api/useSubContractors";
 export { default as useSupervisors } from "./api/useSupervisors";
 export { default as useUserDetail } from "./api/useUserDetail";

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -34,6 +34,7 @@ const apiBase = "/api/";
 const apiPi = "/api/pi/";
 const apiRecords = "/api/records/";
 const apiComments = "/api/comments/";
+const apiTicketVote = "/api/ticketvote/";
 
 const getUrl = (path, version, api = apiBase) => {
   if (!path && !version) return api;
@@ -529,7 +530,7 @@ export const user = (userId) => GET(`/user/${userId}`).then(getResponse);
 export const proposalComments = (csrf, token, state) =>
   POST("/comments", csrf, { token, state }, apiPi).then(getResponse);
 
-export const commentsTimestamp = (csrf, token, state, commentids) =>
+export const commentsTimestamps = (csrf, token, state, commentids) =>
   POST("/timestamps", csrf, { token, state, commentids }, apiComments).then(
     getResponse
   );
@@ -615,6 +616,9 @@ export const proposalsBatchVoteSummary = (csrf, tokens) =>
 
 export const proposalVoteResults = (csrf, token) =>
   POST("/votes/results", csrf, { token }, apiPi).then(getResponse);
+
+export const ticketVoteTimestamps = (csrf, token) =>
+  POST("/timestamps", csrf, { token }, apiTicketVote).then(getResponse);
 
 export const proposalAuthorizeOrRevokeVote = (
   csrf,

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -33,6 +33,7 @@ export const TOP_LEVEL_COMMENT_PARENTID = 0;
 const apiBase = "/api/";
 const apiPi = "/api/pi/";
 const apiRecords = "/api/records/";
+const apiComments = "/api/comments/";
 
 const getUrl = (path, version, api = apiBase) => {
   if (!path && !version) return api;
@@ -527,6 +528,11 @@ export const user = (userId) => GET(`/user/${userId}`).then(getResponse);
 
 export const proposalComments = (csrf, token, state) =>
   POST("/comments", csrf, { token, state }, apiPi).then(getResponse);
+
+export const commentsTimestamp = (csrf, token, state, commentids) =>
+  POST("/timestamps", csrf, { token, state, commentids }, apiComments).then(
+    getResponse
+  );
 
 export const invoiceComments = (token) =>
   GET(`/invoices/${token}/comments`).then(getResponse);

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -32,6 +32,7 @@ export const TOP_LEVEL_COMMENT_PARENTID = 0;
 
 const apiBase = "/api/";
 const apiPi = "/api/pi/";
+const apiRecords = "/api/records/";
 
 const getUrl = (path, version, api = apiBase) => {
   if (!path && !version) return api;
@@ -658,6 +659,11 @@ export const proposalsInventory = (csrf) =>
 
 export const votesInventory = (csrf) =>
   POST("/votes/inventory", csrf, {}, apiPi).then(getResponse);
+
+export const recordsTimestamp = (csrf, token, state, version) =>
+  POST("/timestamps", csrf, { token, state, version }, apiRecords).then(
+    getResponse
+  );
 
 // CMS
 

--- a/src/selectors/models/proposalVotes.js
+++ b/src/selectors/models/proposalVotes.js
@@ -13,7 +13,7 @@ export const makeGetProposalVoteResults = (token) =>
     makeGetProposalVoteSummary(token),
     (summary) =>
       summary && {
-        castvotes: summary.castvotes,
+        castvotes: summary.votes,
         startvotereply: summary.startvotereply
       }
   );


### PR DESCRIPTION
Tlog allows us to retrieve the **inclusion proof timestamp** for any single piece of data. This diff adds the possibility to download timestamps for:

- [x] Records

- [x] Comments

- [x] Votes

### Solution description

In order to keep this usable and accessible for the average user, a Download Link is displayed on Proposal details page, where it can download the regarded **timestamp**.

### UI Changes Screenshot

<img width="1455" alt="Screen Shot 2021-01-13 at 5 25 19 PM" src="https://user-images.githubusercontent.com/22639213/104506558-54d30a80-55c4-11eb-99d6-8190a524e232.png">

